### PR TITLE
adds docker-compose file with node and rabbitmq services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3'
+services:
+  rabbitmq:
+    image: 'rabbitmq:management'
+    container_name: trollblock_rabbitmq
+    ports:
+      - '5672:5672'
+      - '15672:15672'
+    networks:
+     - trollblock
+  waitforrabbit:
+    image: dadarek/wait-for-dependencies
+    depends_on:
+      - rabbitmq
+    command: rabbitmq:5672
+    networks:
+     - trollblock
+  node:
+    build:
+      context: ./docker/node
+      dockerfile: Dockerfile
+    container_name: trollblock_node
+    ports:
+      - '80:8080'
+    env_file: .env
+    user: node
+    volumes:
+     - .:/home/node/app
+    networks:
+     - trollblock
+    depends_on:
+      - waitforrabbit
+networks:
+  trollblock:
+    driver: "bridge"

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:8-alpine
+
+RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
+
+WORKDIR /home/node/app
+
+RUN npm install
+
+COPY . .
+
+COPY --chown=node:node . .
+
+USER node
+
+EXPOSE 8080
+
+CMD [ "node", "app.js" ]
+
+


### PR DESCRIPTION
steps to launch containerized version 
1. Install Docker and Docker Compose
2. build docker containers
      docker-compose build
3. start docker services
      docker-compose up

Access node app via http://localhost
Access RabbitMQ web interface via http://localhost:15672